### PR TITLE
Make instagram transition only be triggered from left edge

### DIFF
--- a/Development/Sources/FluidInterfaceKit-Demo/DemoThreadsMessagesViewController.swift
+++ b/Development/Sources/FluidInterfaceKit-Demo/DemoThreadsMessagesViewController.swift
@@ -116,6 +116,8 @@ final class DemoThreadsMessagesViewController: FluidStackController {
                       topBar: .navigation
                     )
                   )
+                
+                  controller.setupNonDraggableArea(edge: .init(top: 0, left: 20, bottom: 0, right: 0))
 
                   viewControllerCache[index] = controller
 


### PR DESCRIPTION
Hello Muukii-san

I read a little bit code. 
This may be a workaround. but not a perfect solution definitely. 

The use case is to support instagram transition. but only can be triggered from left edge. 
Do you have any better suggestion? 