### PR TITLE
Post `.screenChanged` event on some screen transitions that need manual invocation

### DIFF
--- a/Sources/FluidStack/ViewController/FluidStackController.swift
+++ b/Sources/FluidStack/ViewController/FluidStackController.swift
@@ -178,7 +178,7 @@ open class FluidStackController: UIViewController {
   // MARK: - Functions
   
   open func stackingViewControllersDidChange(_ viewControllers: [UIViewController]) {
-    
+    UIAccessibility.post(notification: .screenChanged, argument: nil)
   }
   
   public func stackingDescription() -> String {
@@ -385,6 +385,7 @@ open class FluidStackController: UIViewController {
 
     newTransitionContext.addCompletionEventHandler { event in
       completion?(event)
+      UIAccessibility.post(notification: .screenChanged, argument: nil)
     }
 
     platterView.swapTransitionContext(newTransitionContext)
@@ -953,11 +954,10 @@ open class PresentationFluidStackController: FluidStackController {
   }
   
   open override func stackingViewControllersDidChange(_ viewControllers: [UIViewController]) {
-    
     if viewControllers.isEmpty {
       dismiss(animated: false)
     }
-    
+    UIAccessibility.post(notification: .screenChanged, argument: nil)
   }
   
 }


### PR DESCRIPTION
This makes all transitions on the Demo app controllable using just VoiceOver highlighting.

TODO: Snackbars need manual handling for the `.announcement` event, since they require a text hint that needs to be automatically read by VoiceOver without changing the existing focus.