### PR TITLE
Make floating display scene-aware

### DIFF
--- a/Sources/FluidCore/SafeAreaFinder.swift
+++ b/Sources/FluidCore/SafeAreaFinder.swift
@@ -12,9 +12,11 @@ import UIKit
 public final class SafeAreaFinder: NSObject {
 
   public static let notificationName = Notification.Name(rawValue: "app.muukii.fluid.SafeAreaInsetsManager")
-  
-  @MainActor
-  public static let shared = SafeAreaFinder()
+
+  @available(iOS 13.0, *)
+  public weak var windowScene: UIWindowScene?
+
+  public weak var window: UIWindow?
 
   private var currentInsets: UIEdgeInsets? = nil
 
@@ -30,10 +32,31 @@ public final class SafeAreaFinder: NSObject {
 
   private nonisolated(unsafe) var currentDisplayLink: CADisplayLink!
 
-  private override init() {
+  public override init() {
 
     super.init()
 
+    setUpDisplayLink()
+  }
+
+  @available(iOS 13.0, *)
+  public init(windowScene: UIWindowScene) {
+    self.windowScene = windowScene
+
+    super.init()
+
+    setUpDisplayLink()
+  }
+
+  public init(window: UIWindow) {
+    self.window = window
+
+    super.init()
+
+    setUpDisplayLink()
+  }
+
+  private func setUpDisplayLink() {
     currentDisplayLink = .init(target: self, selector: #selector(handle))
     currentDisplayLink.preferredFramesPerSecond = 1
     currentDisplayLink.add(to: .main, forMode: .default)
@@ -60,6 +83,19 @@ public final class SafeAreaFinder: NSObject {
   }
 
   @objc private dynamic func handle() {
+    if let window {
+      _handle(in: window)
+      return
+    }
+
+    if #available(iOS 13.0, *), let windowScene {
+      guard let window = windowScene.windows.first(where: \.isKeyWindow) ?? windowScene.windows.first else {
+        return
+      }
+      _handle(in: window)
+      return
+    }
+
     guard let window = UIApplication.shared.delegate?.window ?? nil else {
       return
     }
@@ -134,7 +170,7 @@ public final class SafeAreaFinder: NSObject {
 
     if currentInsets != maximumInsets {
       currentInsets = maximumInsets
-      NotificationCenter.default.post(name: Self.notificationName, object: maximumInsets)
+      NotificationCenter.default.post(name: Self.notificationName, object: maximumInsets, userInfo: ["finder": self])
     }
   }
 

--- a/Sources/FluidPictureInPicture/FluidPictureInPictureController.swift
+++ b/Sources/FluidPictureInPicture/FluidPictureInPictureController.swift
@@ -104,6 +104,7 @@ extension FluidPictureInPictureController {
     let containerView: ContainerView = .init()
 
     let sizeForFloating = CGSize(width: 100, height: 140)
+    let safeAreaFinder = SafeAreaFinder()
         
     private(set) var state: State = .init() {
       didSet {
@@ -145,6 +146,7 @@ extension FluidPictureInPictureController {
     }
     
     @objc private func handleInsetsUpdate(notification: Notification) {
+      guard notification.userInfo?["finder"] as? SafeAreaFinder === safeAreaFinder else { return }
       let inset = notification.object as! UIEdgeInsets
       state.inset = inset
       setNeedsLayout()
@@ -229,11 +231,13 @@ extension FluidPictureInPictureController {
     
     override func didMoveToWindow() {
       super.didMoveToWindow()
-      
+
+      safeAreaFinder.window = window
+
       if window != nil {
-        SafeAreaFinder.shared.start()
+        safeAreaFinder.start()
       } else {
-        SafeAreaFinder.shared.pause()
+        safeAreaFinder.pause()
       }
     }
     

--- a/Sources/FluidSnackbar/FloatingDisplayController.swift
+++ b/Sources/FluidSnackbar/FloatingDisplayController.swift
@@ -37,6 +37,17 @@ open class FloatingDisplayController {
     self.displayTarget = .init(edgeTargetSafeArea: edgeTargetSafeArea)
   }
 
+  @available(iOS 13.0, *)
+  public init(
+    edgeTargetSafeArea: FloatingDisplayTarget.EdgeTargetSafeArea,
+    windowScene: UIWindowScene
+  ) {
+    self.displayTarget = .init(
+      edgeTargetSafeArea: edgeTargetSafeArea,
+      windowScene: windowScene
+    )
+  }
+
 // MARK: - Functions
 
   private func drain() {

--- a/Sources/FluidSnackbar/FloatingDisplayTarget.swift
+++ b/Sources/FluidSnackbar/FloatingDisplayTarget.swift
@@ -48,6 +48,7 @@ public final class FloatingDisplayTarget {
   }
 
   private let notificationWindow: NotificationWindow
+  private let safeAreaFinder: SafeAreaFinder
   private let notificationViewController: NotificationViewController
 
   public var additionalSafeAreaInsets: UIEdgeInsets {
@@ -78,26 +79,59 @@ public final class FloatingDisplayTarget {
 
   public init(edgeTargetSafeArea: EdgeTargetSafeArea) {
 
-    self.notificationViewController = .init(edgeTargetSafeArea: edgeTargetSafeArea)
-
     if #available(iOS 13, *) {
-
       let windowScene = UIApplication.shared
         .connectedScenes
         .lazy
-        .filter { $0.activationState == .foregroundActive }
-        .compactMap { $0 as? UIWindowScene }
+        .filter({ $0.activationState == .foregroundActive })
+        .compactMap({ $0 as? UIWindowScene })
         .first
-
-      if let windowScene = windowScene {
+      if let windowScene {
+        self.safeAreaFinder = .init(windowScene: windowScene)
+        self.notificationViewController = .init(
+          edgeTargetSafeArea: edgeTargetSafeArea,
+          safeAreaFinder: safeAreaFinder
+        )
         notificationWindow = .init(windowScene: windowScene)
       } else {
+        self.safeAreaFinder = .init()
+        self.notificationViewController = .init(
+          edgeTargetSafeArea: edgeTargetSafeArea,
+          safeAreaFinder: safeAreaFinder
+        )
         notificationWindow = .init(frame: .zero)
       }
 
     } else {
+      self.safeAreaFinder = .init()
+      self.notificationViewController = .init(
+        edgeTargetSafeArea: edgeTargetSafeArea,
+        safeAreaFinder: safeAreaFinder
+      )
       notificationWindow = .init(frame: .zero)
     }
+
+    notificationWindow.windowLevel = UIWindow.Level(rawValue: 5)
+    notificationWindow.isHidden = true
+    notificationWindow.backgroundColor = UIColor.clear
+    notificationWindow.frame = UIScreen.main.bounds
+    notificationViewController.beginAppearanceTransition(true, animated: false)
+    notificationWindow.rootViewController = notificationViewController
+    notificationViewController.endAppearanceTransition()
+  }
+
+  @available(iOS 13.0, *)
+  public init(
+    edgeTargetSafeArea: EdgeTargetSafeArea,
+    windowScene: UIWindowScene
+  ) {
+
+    self.safeAreaFinder = .init(windowScene: windowScene)
+    self.notificationViewController = .init(
+      edgeTargetSafeArea: edgeTargetSafeArea,
+      safeAreaFinder: safeAreaFinder
+    )
+    self.notificationWindow = .init(windowScene: windowScene)
 
     notificationWindow.windowLevel = UIWindow.Level(rawValue: 5)
     notificationWindow.isHidden = true
@@ -149,9 +183,14 @@ extension FloatingDisplayTarget {
   fileprivate final class NotificationViewController: UIViewController {
 
     private let edgeTargetSafeArea: EdgeTargetSafeArea
+    private let safeAreaFinder: SafeAreaFinder
 
-    init(edgeTargetSafeArea: EdgeTargetSafeArea) {
+    init(
+      edgeTargetSafeArea: EdgeTargetSafeArea,
+      safeAreaFinder: SafeAreaFinder
+    ) {
       self.edgeTargetSafeArea = edgeTargetSafeArea
+      self.safeAreaFinder = safeAreaFinder
       super.init(nibName: nil, bundle: nil)
     }
 
@@ -160,7 +199,10 @@ extension FloatingDisplayTarget {
     }
 
     override fileprivate func loadView() {
-      view = View(edgeTargetSafeArea: edgeTargetSafeArea)
+      view = View(
+        edgeTargetSafeArea: edgeTargetSafeArea,
+        safeAreaFinder: safeAreaFinder
+      )
     }
 
     override fileprivate func viewDidLoad() {
@@ -172,6 +214,7 @@ extension FloatingDisplayTarget {
     fileprivate class View: UIView {
 
       private let edgeTargetSafeArea: EdgeTargetSafeArea
+      private let safeAreaFinder: SafeAreaFinder
 
       private var _safeAreaLayoutGuide: UILayoutGuide = .init()
       private var activeWindowSafeAreaLayoutGuideConstraintLeft: NSLayoutConstraint?
@@ -181,9 +224,13 @@ extension FloatingDisplayTarget {
 
       private var hasSafeAreaFinderActivated: Bool = false
 
-      init(edgeTargetSafeArea: EdgeTargetSafeArea) {
+      init(
+        edgeTargetSafeArea: EdgeTargetSafeArea,
+        safeAreaFinder: SafeAreaFinder
+      ) {
 
         self.edgeTargetSafeArea = edgeTargetSafeArea
+        self.safeAreaFinder = safeAreaFinder
 
         super.init(frame: .zero)
 
@@ -248,13 +295,14 @@ extension FloatingDisplayTarget {
           NotificationCenter.default.addObserver(
             self, selector: #selector(handleInsetsUpdate), name: SafeAreaFinder.notificationName,
             object: nil)
-          SafeAreaFinder.shared.start()
+          safeAreaFinder.start()
         }
       }
 
       @objc private func handleInsetsUpdate(notification: Notification) {
 
         guard hasSafeAreaFinderActivated else { return }
+        guard notification.userInfo?["finder"] as? SafeAreaFinder === safeAreaFinder else { return }
 
         let insets = notification.object as! UIEdgeInsets
         self.activeWindowSafeAreaLayoutGuideConstraintLeft?.constant = insets.left
@@ -287,9 +335,9 @@ extension FloatingDisplayTarget {
       }
 
       deinit {
-        Task { @MainActor [hasSafeAreaFinderActivated] in 
+        Task { @MainActor [hasSafeAreaFinderActivated, safeAreaFinder] in
           if hasSafeAreaFinderActivated {
-            SafeAreaFinder.shared.pause()
+            safeAreaFinder.pause()
           }
         }
       }


### PR DESCRIPTION
## What changed
- Added `UIWindowScene`-aware initializers to `FloatingDisplayController` and `FloatingDisplayTarget`
- Propagated scene/window context into `SafeAreaFinder`
- Replaced `SafeAreaFinder.shared` usage with owner-local finder instances
- Scoped safe-area notifications to the originating finder instance to avoid cross-scene mixing
- Preserved the existing initializer path with fallback behavior for backward compatibility

## Why
- The original implementation assumed a single active app scene
- `FloatingDisplayTarget` selected a foreground scene implicitly
- safe-area lookup could resolve the wrong window because scene context was not passed through
- this breaks multi-scene apps

## Context from the request
- Pass the target scene into `FloatingDisplayController` initialization
- Fix the logic that effectively behaved like a single-app assumption via `.foregroundActive`
- Make safe-area resolution scene-aware without relying on a shared singleton instance

